### PR TITLE
feat: add input of the product quantity

### DIFF
--- a/filter_by_product.rb
+++ b/filter_by_product.rb
@@ -1,0 +1,6 @@
+PRODUCT_MAX = 100
+
+puts 'Product registration.'
+
+print "Number of products to register (max #{PRODUCT_MAX}): "
+quantityOfProduct = gets.chomp.to_i


### PR DESCRIPTION
## What

An `input` field was added for the user to enter the number of products he wants to register, using a maximum number of `100`.

## Why

It will be necessary to have a `quantity parameter` in order to register products, so we let the user make that choice themselves.

## How

- A `global constant` was used to store the value 100, which will be the maximum parameter for the quantity of products.
- We used the `gets.chomp` method to retrieve data entered by the user.
- The `to_i` method was used to convert all input into an integer number.