### PR TITLE
feat: add restriction for duplicate code

### DIFF
--- a/filter_by_product.rb
+++ b/filter_by_product.rb
@@ -7,8 +7,16 @@ print "\nNumber of products to register (max #{PRODUCT_MAX}): "
 quantityOfProduct = gets.chomp.to_i
 
 quantityOfProduct.times do |product|
-  print "Enter the product code #{product + 1}: "
-  code = gets.chomp.to_i
+  code = nil
+
+  loop do
+    print "Enter the product code #{product + 1}: "
+    code = gets.chomp.to_i
+
+    break unless products.any? { |product| product[:code] == code }
+
+    puts 'This code has already been entered. Please enter a different code.'
+  end
 
   print "Enter the quantity of the product #{product + 1}: "
   quantity = gets.chomp.to_i


### PR DESCRIPTION
## What
A restriction was added to prevent duplicate product codes.

## Why
This ensures data consistency by avoiding duplicated product codes.

## How
- Simply by adding a loop inside the `times loop` to enforce the necessary restrictions.